### PR TITLE
 Added block hash to getaddressunspent outputs

### DIFF
--- a/lib/commands.py
+++ b/lib/commands.py
@@ -206,6 +206,10 @@ class Commands:
                 if raw:
                     tx = Transaction(raw)
                     output['inputs'] = tx.inputs()
+
+            if "height" in output:
+                output['block_hash'] = self.network.get_block_hash(output['height'])
+
         height = self.network.get_server_height()
         json_obj = {'chain_height': height}
         results.append(json_obj)


### PR DESCRIPTION
updated getaddressunspent to include the block hash of the confirmed transaction. Used to verify that the tx summary is on the majority fork in zdex. The changes are backwards compatible so it should interface with zdex just fine.